### PR TITLE
Version 0.9.0

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -107,6 +107,9 @@
   "allOf": [
     {
       "properties": {
+        "EnableForkedRepository": {
+          "type": "boolean"
+        },
         "Folder": {
           "type": "string"
         },
@@ -117,11 +120,11 @@
         "MainName": {
           "type": "string"
         },
-        "NugetApiKey": {
+        "NuGetApiKey": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
-        "NugetApiUrl": {
+        "NuGetApiUrl": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
@@ -149,7 +152,7 @@
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
         },
-        "UnlistNuget": {
+        "UnlistNuGet": {
           "type": "boolean"
         }
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 - Support `Revit 2026` projects and solutions.
 ### Updated
-- Change debug to include `RevitVersion` when `!NoRevitVersion`.
+- Change debug to include `RevitVersion` when `!NoRevitVersion`. (Fix: #21)
 
 ## [0.8.3] / 2025-04-04
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] / 2025-04-09
+### Features
+- Support `Revit 2026` projects and solutions.
+### Updated
+- Change debug to include `RevitVersion` when `!NoRevitVersion`.
+
 ## [0.8.3] / 2025-04-04
 ### Features
 - Support `Revit 2026` projects and solutions.
@@ -120,6 +126,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Solution `ricaun-revit-addin-23-17-sln`
 
 [vNext]: ../../compare/1.0.0...HEAD
+[0.9.0]: ../../compare/0.8.3...0.9.0
 [0.8.3]: ../../compare/0.8.2...0.8.3
 [0.8.2]: ../../compare/0.8.1...0.8.2
 [0.8.1]: ../../compare/0.8.0...0.8.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.8.3</Version>
+		<Version>0.9.0-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.0-alpha</Version>
+		<Version>0.9.0-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.9.0-rc</Version>
+		<Version>0.9.0</Version>
 	</PropertyGroup>
 </Project>

--- a/ricaun.Revit.Templates/content/ProjectTemplates/ricaun.Revit.Addin.Project/ricaun.Revit.Addin.Project.csproj
+++ b/ricaun.Revit.Templates/content/ProjectTemplates/ricaun.Revit.Addin.Project/ricaun.Revit.Addin.Project.csproj
@@ -150,7 +150,12 @@
   <!-- Debug -->
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
     <DebugSymbols>true</DebugSymbols>
+<!--#if (!NoRevitVersion)
+    <OutputPath>bin\Debug\$(RevitVersion)</OutputPath>
+#endif-->
+<!--#if (NoRevitVersion)
     <OutputPath>bin\Debug\</OutputPath>
+#endif-->
     <DefineConstants>$(DefineConstants);DEBUG;TRACE;REVIT$(RevitVersion)</DefineConstants>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/ricaun.Revit.Templates/content/SolutionTemplates/ricaun.Solution.Revit.Addin.Template/SolutionTemplates/SolutionTemplates.csproj
+++ b/ricaun.Revit.Templates/content/SolutionTemplates/ricaun.Solution.Revit.Addin.Template/SolutionTemplates/SolutionTemplates.csproj
@@ -150,7 +150,12 @@
   <!-- Debug -->
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
     <DebugSymbols>true</DebugSymbols>
+<!--#if (!NoRevitVersion)
+    <OutputPath>bin\Debug\$(RevitVersion)</OutputPath>
+#endif-->
+<!--#if (NoRevitVersion)
     <OutputPath>bin\Debug\</OutputPath>
+#endif-->
     <DefineConstants>$(DefineConstants);DEBUG;TRACE;REVIT$(RevitVersion)</DefineConstants>
     <DebugType>Full</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
### Features
- Support `Revit 2026` projects and solutions.
### Updated
- Change debug to include `RevitVersion` when `!NoRevitVersion`. (Fix: #21)